### PR TITLE
feat: enhanced fail2ban with openvpn

### DIFF
--- a/roles/fail2ban/README.md
+++ b/roles/fail2ban/README.md
@@ -5,7 +5,9 @@ This role enables fail2ban
 
 ## Variables
 
-none
+Set in `defaults`: 
+
+`fail2ban_openvpn_retry` sets the number of failed openvpn connections from a certain ip until fail2ban locks the port for that ip
 
 ## Implementation notes
 

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,1 @@
+fail2ban_openvpn_retry: 5

--- a/roles/fail2ban/files/etc/fail2ban/filter.d/openvpn.local
+++ b/roles/fail2ban/files/etc/fail2ban/filter.d/openvpn.local
@@ -1,0 +1,15 @@
+# Inspired by https://www.fail2ban.org/wiki/index.php/HOWTO_fail2ban_with_OpenVPN
+# but adjusted for bullseye (tested with openvpn 2.5.1-3)
+
+[Definition]
+# Example messages :
+# Jan  7 12:43:30 mimas4 openvpn[646]: 46.234.123.248:26802 TLS Error: TLS key negotiation failed to occur within 60 seconds (check your network connectivity)
+# Jan  7 12:43:30 mimas4 openvpn[646]: 46.234.123.248:26802 TLS Error: TLS handshake failed
+# add only one of them to count each connect only once. Note that these error message comes with a delay of 60 seconds, so an attacker
+# can try whatever he/she wishes to.
+# regex for 2nd message:
+#  ^.* openvpn\[\d+\]: <HOST>:\d+ TLS Error: TLS key negotiation failed to occur within 60 seconds \(check your network connectivity\)$
+
+failregex = ^.* openvpn\[\d+\]: <HOST>:\d+ TLS Error: TLS handshake failed$
+
+ignoreregex = 

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -16,9 +16,21 @@
     dest: /etc/fail2ban/jail.local
   register: configfail2ban
 
+- name: Add filter rule for openvpn
+  ansible.builtin.copy:
+    src: etc/fail2ban/filter.d/openvpn.local
+    dest: /etc/fail2ban/filter.d/openvpn.local
+  register: configfail2banopenvpnfilter
+
+- name: Configure jail for openvpn
+  ansible.builtin.template:
+    src: etc/fail2ban/jail.d/openvpn.local.j2
+    dest: /etc/fail2ban/jail.d/openvpn.local
+  register : configfail2banopenvpnjail
+
 - name: Ensure fail2ban is active and started
   ansible.builtin.systemd:
     name: fail2ban
     state: restarted
     enabled: yes
-  when: configfail2ban.changed
+  when: configfail2ban.changed or configfail2banopenvpnfilter.changed or configfail2banopenvpnjail.changed

--- a/roles/fail2ban/templates/etc/fail2ban/jail.d/openvpn.local.j2
+++ b/roles/fail2ban/templates/etc/fail2ban/jail.d/openvpn.local.j2
@@ -1,0 +1,7 @@
+[openvpn]
+enabled  = true
+port     = 1194
+protocol = udp
+filter   = openvpn
+logpath  = /var/log/daemon.log
+maxretry = {{ fail2ban_openvpn_retry }}


### PR DESCRIPTION
After having cleanup the logs a bit, I noticed regular connection attempts on the openvpn port. The current debian package  seems not provide any rules openvpn.